### PR TITLE
Fixed t/20-zombie.t ..... Can't locate Time/HiRes.pm in @INC on run make test

### DIFF
--- a/t/20-zombie.t
+++ b/t/20-zombie.t
@@ -3,7 +3,9 @@ use warnings;
 use Test::More;
 use System::Command;
 use File::Spec;
-use Time::HiRes qw( time );
+
+eval "use Time::HiRes qw( time )";
+plan skip_all => "Time::HiRes required for testing" if $@;
 
 my @cmd = ( $^X, File::Spec->catfile( t => 'fail.pl' ) );
 


### PR DESCRIPTION
``` bash
Fixed t/20-zombie.t ..... Can't locate Time/HiRes.pm in @INC (@INC contains: /opt/github/System-Command/blib/lib /opt/github/System-Command/blib/arch /usr/local/lib/perl5 /usr/local/share/perl5 /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5 /usr/share/perl5 .) at t/20-zombie.t line 6.
BEGIN failed--compilation aborted at t/20-zombie.t line 6.

Test Summary Report
-------------------
t/20-zombie.t   (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output

Added skip tests if Time::HiRes not found.
```
