### PR TITLE
Fixed warning Argument "6.55_02" isn't numeric in numeric ge (>=)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ WriteMakefile(
     AUTHOR              => q{Philippe Bruhat (BooK) <book@cpan.org>},
     VERSION_FROM        => 'lib/System/Command.pm',
     ABSTRACT_FROM       => 'lib/System/Command.pm',
-    ($ExtUtils::MakeMaker::VERSION >= 6.3002
+    ($ExtUtils::MakeMaker::VERSION ge '6.3002'
       ? ('LICENSE'=> 'perl')
       : ()),
     PL_FILES            => {},


### PR DESCRIPTION
Fixed
% perl Makefile.PL
Argument "6.55_02" isn't numeric in numeric ge (>=) at Makefile.PL line 5.
Writing Makefile for System::Command.
