### PR TITLE
Changed Sytem::Command::Reaper::_reap() to work on Solaris 10.

### DIFF
--- a/lib/System/Command/Reaper.pm
+++ b/lib/System/Command/Reaper.pm
@@ -41,11 +41,14 @@ sub is_terminated {
 }
 
 sub _reap {
-    my ( $self, @flags ) = @_;
+    my ( $self, $flags ) = @_;
+
+    $flags = 0 if ! defined $flags;
+
     my $pid = $self->{pid};
 
     # REPENT/THE END IS/EXTREMELY/FUCKING/NIGH
-    if ( my $reaped = waitpid( $pid, @flags ) and !exists $self->{exit} ) {
+    if ( my $reaped = waitpid( $pid, $flags ) and !exists $self->{exit} ) {
         my $zed = $reaped == $pid;
         carp "Child process already reaped, check for a SIGCHLD handler"
             if !$zed && !$System::Command::QUIET && !MSWin32;


### PR DESCRIPTION
Calling
waitpid( $pid, @flags ) does not work on Solaris 10. Changed to
waitpid( $pid, $flags ).

Tests passed on Linux and Solaris 10 as well.
Installable on both systems now.
