### PR TITLE
throw an error on empty string env variables on Win32

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for System-Command
 
 {{$NEXT}}
+    [ENHANCEMENTS]
+    - throw an error on empty string env variables on Win32
 
 1.110 Wed Aug 27 2014
     [ENHANCEMENTS]

--- a/lib/System/Command.pm
+++ b/lib/System/Command.pm
@@ -222,6 +222,8 @@ sub new {
 
     # update the environment
     if ( exists $o->{env} ) {
+        croak "ENV variables cannot be empty strings on Win32"
+            if MSWin32 and grep { defined and !length } values %{ $o->{env} };
         @ENV{ keys %{ $o->{env} } } = values %{ $o->{env} };
         delete $ENV{$_}
             for grep { !defined $o->{env}{$_} } keys %{ $o->{env} };


### PR DESCRIPTION
Setting an env var to empty string on Win32 deletes it, so they should throw an error. This patch implements that and adapts the tests accordingly.