### PR TITLE
Add reftype (needed for 'interactive' option)

### DIFF
--- a/lib/System/Command.pm
+++ b/lib/System/Command.pm
@@ -8,7 +8,7 @@ use Carp;
 use Cwd qw( cwd );
 use IO::Handle;
 use Symbol ();
-use Scalar::Util qw( blessed );
+use Scalar::Util qw( blessed reftype );
 use List::Util qw( reduce );
 use System::Command::Reaper;
 


### PR DESCRIPTION
This is required for the 'interactive' option to work. Otherwise, it throws this error:
```
Undefined subroutine &System::Command::reftype
```