### PR TITLE
fix mwin32 test 20-zombie.t, was broken in Strawberry Perl

### DIFF
--- a/t/20-zombie.t
+++ b/t/20-zombie.t
@@ -21,8 +21,10 @@ my $status = 1;
 my $delay  = 2;
 
 # this is necessary, because kill(0,pid) is misimplemented in perl core
+# note that MW tasklist does not provide a return code; pipe to find to obtain return code
 my $_is_alive = $win32
-    ? sub { return `tasklist /FO CSV /NH /fi "PID eq $_[0]"` =~ /^"/ }
+	? sub { return `tasklist /FO CSV /NH /fi "PID eq $_[0]" 2>NUL | find /I /N "$_[0]">NUL` }
+#    ? sub { return `tasklist /FO CSV /NH /fi "PID eq $_[0]"` =~ /^"/ }
     : sub { return kill 0, $_[0]; };
 
 # catch warnings
@@ -138,8 +140,9 @@ BEGIN { $tests += 4 }
 
         # zombies do not exist under win32
         my $blip = $_is_alive->($pid);
+
         $win32
-            ? ok( !$blip, "process $pid is gone" )
+            ? ok( !$blip, "process $pid is gone" ) 
             : ok( $blip,  "process $pid is still alive" );
 
         my $ln = <$fh>;


### PR DESCRIPTION
Test failed in Strawberry Perl. MW tasklist command does not return a result code; if the command is piped to "find" on MW, we can obtain the result code. 

Change tested on MW and Cygwin. 