### PR TITLE
Fix tests on Win32

### DIFF
--- a/t/10-command.t
+++ b/t/10-command.t
@@ -157,17 +157,18 @@ for my $t ( @tests, @fail ) {SKIP:{
     my $w32env = {};
     $w32env = { PWD => $t->{options}{cwd} }
         if MSWin32 && exists $t->{options}{cwd};
-    is_deeply(
-        $info,
-        {   argv  => [],
-            cwd   => $t->{options}{cwd} || $cwd,
-            env   => { %$env, %$w32env },
-            input => $t->{options}{input} || '',
-            name  => $t->{name} || $name,
-            pid   => $cmd->pid,
-        },
-        "perl $name"
-    );
+    my $expected = {   argv  => [],
+        cwd   => $t->{options}{cwd} || $cwd,
+        env   => { %$env, %$w32env },
+        input => $t->{options}{input} || '',
+        name  => $t->{name} || $name,
+        pid   => $cmd->pid,
+    };
+    is_deeply($info, $expected, "perl $name") or do {
+        diag '$t: ', explain $t;
+        diag '$info: ', explain $info;
+        diag '$expected: ', explain $expected;
+    };
 
     # close and check
     my $reaper = $cmd->close();

--- a/t/10-command.t
+++ b/t/10-command.t
@@ -152,6 +152,11 @@ for my $t ( @tests, @fail ) {SKIP:{
         for grep { !defined $t->{options}{env}{$_} }
         keys %{ $t->{options}{env} || {} };
     delete $env->{$_} for grep /^CONEMU/, keys %ENV;
+    if (MSWin32) {
+        # env vars can't be empty strings on Win32
+        # seems GNU make is adding an empty-string MFLAGS env-var which causes mayhem
+        delete $env->{$_} for grep !length $env->{$_}, keys %$env;
+    }
     my $info;
     eval $output;
     my $w32env = {};

--- a/t/info.pl
+++ b/t/info.pl
@@ -6,6 +6,9 @@ use Data::Dumper;
 
 my $input = $ENV{SYSTEM_COMMAND_INPUT} ? join( '', <> ) : '';
 
+{
+local $Data::Dumper::Sortkeys = 1;
+local $Data::Dumper::Indent = 1;
 print Data::Dumper->Dump(
     [   {   argv  => \@ARGV,
             env   => \%ENV,
@@ -17,3 +20,4 @@ print Data::Dumper->Dump(
     ],
     ['info']
 );
+}


### PR DESCRIPTION
A couple of tidy-ups and improvement of test output, but mostly to zap environment variables that make all the tests in `t/10-command.t` fail on Win32 under GNU make.