### PR TITLE
Localize $? and $! in DESTROY method

### DIFF
--- a/lib/System/Command/Reaper.pm
+++ b/lib/System/Command/Reaper.pm
@@ -112,6 +112,8 @@ sub close {
 
 sub DESTROY {
     my ($self) = @_;
+    local $?;
+    local $!;
     $self->close if !exists $self->{exit};
 }
 


### PR DESCRIPTION
When a System::Command object is destroyed, it might overwrite $? and
$!. This is a problem if called during global destruction, because it
can make a program that should exit non-zero actually exit zero instead.

Here's an example, which exits 0 because `ls` exits 0.

```
use strict;
use warnings;
use System::Command;

my $out = System::Command->new("ls")->stdout;
my $line = <$out>;

die "uh oh, the zombies are coming";
```

Localizing $? and $! during the Reaper's DESTROY method is sufficient
not to clobber these. See also Github #27.